### PR TITLE
Making the repo and tag values file section consitent with the rest

### DIFF
--- a/administration/transactioneventapi/templates/deployment.yaml
+++ b/administration/transactioneventapi/templates/deployment.yaml
@@ -26,8 +26,7 @@ spec:
     spec:
       containers:
         - name: {{ .Chart.Name }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
-          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          image: "{{ .Values.imagestore.transactioneventapi.repository }}:{{ .Values.imagestore.transactioneventapi.tag }}"
           ports:
             - name: http
               containerPort: {{ .Values.deployment.containerPort }}

--- a/administration/transactioneventapi/values.yaml
+++ b/administration/transactioneventapi/values.yaml
@@ -3,10 +3,6 @@
 # Declare variables to be passed into your templates.
 fullnameOverride: transactioneventapi
 replicaCount: 1
-image:
-  repository: glasswallsolutions/transactioneventapi
-  tag: main-latest
-  pullPolicy: IfNotPresent
 imagePullSecrets: []
   # Optionally specify an array of imagePullSecrets.
   # Secrets must be manually created in the namespace.
@@ -63,3 +59,7 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+imagestore:
+  transactioneventapi:
+    repository: glasswallsolutions/transactioneventapi
+    tag: main-a9fa630


### PR DESCRIPTION
Decided Seb was more correct with "repository" than "image" so altered the convention for the other services