### PR TITLE
added dns label name to load balancer and mgmt ui

### DIFF
--- a/adaptation/templates/lb_service.yaml
+++ b/adaptation/templates/lb_service.yaml
@@ -1,6 +1,8 @@
 apiVersion: v1
 kind: Service
 metadata:
+  annotations:
+    service.beta.kubernetes.io/azure-dns-label-name: icap-client
   name: frontend-icap-lb
 spec:
   type: LoadBalancer

--- a/administration/management-ui/templates/service.yml
+++ b/administration/management-ui/templates/service.yml
@@ -1,6 +1,8 @@
 apiVersion: v1
 kind: Service
 metadata:
+  annotations:
+    service.beta.kubernetes.io/azure-dns-label-name: management-ui
   name: {{ .Values.service.name }}
 spec:
   selector:


### PR DESCRIPTION
These changes will stop the DNS label names being removed when the pods / services are redeployed or updated.