### PR TITLE
Update Administration cluster to nulling secrets

### DIFF
--- a/administration/templates/policy-management-api/secrets.yaml
+++ b/administration/templates/policy-management-api/secrets.yaml
@@ -1,5 +1,5 @@
 {{- $root := . }}
-{{- range $key, $value  := .Values.policymanagementapi.secrets }}
+{{- range $key, $value  := .Values.secrets.policymanagementapi }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/administration/templates/transaction-query-aggregator/secrets.yaml
+++ b/administration/templates/transaction-query-aggregator/secrets.yaml
@@ -1,5 +1,5 @@
 {{- $root := . }}
-{{- range $key, $value  := .Values.transactionqueryaggregator.secrets }}
+{{- range $key, $value  := .Values.secrets.transactionqueryaggregator}}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/administration/templates/transactioneventapi/secrets.yaml
+++ b/administration/templates/transactioneventapi/secrets.yaml
@@ -1,5 +1,5 @@
 {{- $root := . }}
-{{- range $name, $values := .Values.transactioneventapi.secrets }}
+{{- range $name, $values := .Values.secrets.transactioneventapi }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/administration/values.yaml
+++ b/administration/values.yaml
@@ -129,6 +129,8 @@ imagestore:
     repository: glasswallsolutions/transaction-query-aggregator
     tag: develop-d246daf
 secrets:
+  containerregistry:
+    dockerconfigjson: "<<https://gw-icap-keyvault.vault.azure.net/secrets/az-registry-dockerconfig>>"
   transactionqueryaggregator:
     transactionqueryserviceref:
       username: "<<https://gw-tfstate-Vault.vault.azure.net/secrets/transactionQueryServiceUsername>>"

--- a/administration/values.yaml
+++ b/administration/values.yaml
@@ -144,4 +144,4 @@ secrets:
       password: "<<https://gw-tfstate-Vault.vault.azure.net/secrets/policyUpdateServicePassword>>"
     ncfspolicyupdateserviceref:
       username: "<<https://gw-tfstate-Vault.vault.azure.net/secrets/ncfsPolicyUpdateServiceUsername>>"
-      password: "<<https://gw-tfstate-Vault.vault.azure.net/secrets/ncfsPolicyUpdateServiceUsername>>"  
+      password: "<<https://gw-tfstate-Vault.vault.azure.net/secrets/ncfsPolicyUpdateServicePassword>>"  

--- a/administration/values.yaml
+++ b/administration/values.yaml
@@ -140,10 +140,6 @@ transactionqueryaggregator:
     annotations: {}
     path: /
     tls: []
-  secrets:
-    transactionqueryserviceref:
-      username: "<<https://gw-tfstate-Vault.vault.azure.net/secrets/transactionQueryServiceUsername>>"
-      password: "<<https://gw-tfstate-Vault.vault.azure.net/secrets/transactionQueryServicePassword>>"
   resources: {}
   nodeSelector: {}
   tolerations: []
@@ -165,3 +161,8 @@ imagestore:
     registry: ""
     repository: glasswallsolutions/transaction-query-aggregator
     tag: develop-d246daf
+secrets:
+  transactionqueryaggregator:
+    transactionqueryserviceref:
+      username: "<<https://gw-tfstate-Vault.vault.azure.net/secrets/transactionQueryServiceUsername>>"
+      password: "<<https://gw-tfstate-Vault.vault.azure.net/secrets/transactionQueryServicePassword>>"

--- a/administration/values.yaml
+++ b/administration/values.yaml
@@ -31,27 +31,6 @@ policymanagementapi:
     tls: []
   PolicyUpdateServiceEndpointCsv: https://policy-update-service.icap-adaptation.svc.cluster.local:10000/
   NcfsPolicyUpdateServiceEndpointCsv: https://ncfs-policy-update-service.icap-ncfs.svc.cluster.local:10001/
-  secrets:
-    policymanagementapipv:
-      azurestorageaccountname: "<<https://gw-tfstate-Vault.vault.azure.net/secrets/policyStoreAccountName>>"
-      azurestorageaccountkey: "<<https://gw-tfstate-Vault.vault.azure.net/secrets/policyStoreAccountKey>>"
-    policyupdateserviceref:
-      username: "<<https://gw-tfstate-Vault.vault.azure.net/secrets/policyUpdateServiceUsername>>"
-      password: "<<https://gw-tfstate-Vault.vault.azure.net/secrets/policyUpdateServicePassword>>"
-    ncfspolicyupdateserviceref:
-      username: "<<https://gw-tfstate-Vault.vault.azure.net/secrets/ncfsPolicyUpdateServiceUsername>>"
-      password: "<<https://gw-tfstate-Vault.vault.azure.net/secrets/ncfsPolicyUpdateServiceUsername>>"
-  # Optionally specify a set of secret objects whose values
-  # will be injected as environment variables by default.
-  # You should add this section to a file like secrets.yaml
-  # that is explicitly NOT committed to source code control
-  # and then include it as part of your helm install step.
-  # ref: https://kubernetes.io/docs/concepts/configuration/secret/
-  #
-  # This creates a secret "mysecret" and injects "mypassword"
-  # as the environment variable mysecret_mypassword=password.
-  # mysecret:
-  #   mypassword: password
   resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little
@@ -96,18 +75,6 @@ transactioneventapi:
     # - secretName: chart-example-tls
     #   hosts:
     #     - chart-example.local
-  secrets: {}
-  # Optionally specify a set of secret objects whose values
-  # will be injected as environment variables by default.
-  # You should add this section to a file like secrets.yaml
-  # that is explicitly NOT committed to source code control
-  # and then include it as part of your helm install step.
-  # ref: https://kubernetes.io/docs/concepts/configuration/secret/
-  #
-  # This creates a secret "mysecret" and injects "mypassword"
-  # as the environment variable mysecret_mypassword=password.
-  # mysecret:
-  #   mypassword: password
   resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little
@@ -166,3 +133,13 @@ secrets:
     transactionqueryserviceref:
       username: "<<https://gw-tfstate-Vault.vault.azure.net/secrets/transactionQueryServiceUsername>>"
       password: "<<https://gw-tfstate-Vault.vault.azure.net/secrets/transactionQueryServicePassword>>"
+  policymanagementapi:
+    policymanagementapipv:
+      azurestorageaccountname: "<<https://gw-tfstate-Vault.vault.azure.net/secrets/policyStoreAccountName>>"
+      azurestorageaccountkey: "<<https://gw-tfstate-Vault.vault.azure.net/secrets/policyStoreAccountKey>>"
+    policyupdateserviceref:
+      username: "<<https://gw-tfstate-Vault.vault.azure.net/secrets/policyUpdateServiceUsername>>"
+      password: "<<https://gw-tfstate-Vault.vault.azure.net/secrets/policyUpdateServicePassword>>"
+    ncfspolicyupdateserviceref:
+      username: "<<https://gw-tfstate-Vault.vault.azure.net/secrets/ncfsPolicyUpdateServiceUsername>>"
+      password: "<<https://gw-tfstate-Vault.vault.azure.net/secrets/ncfsPolicyUpdateServiceUsername>>"  


### PR DESCRIPTION
This change enables the same charts to be used in the AKS and Rancher deployments