### PR TITLE
Addition of secret required for creation of Rebuild Pod

### DIFF
--- a/adaptation/templates/rebuild-pod-container-registry-secret.yaml
+++ b/adaptation/templates/rebuild-pod-container-registry-secret.yaml
@@ -1,0 +1,10 @@
+{{- if .Values.secrets }}
+# This secret is required to create the Rebuild processing pod. It is referenced directly in the code.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: regcred
+data:
+  .dockerconfigjson: {{ .Values.secrets.containerregistry.dockerconfigjson }}
+type: kubernetes.io/dockerconfigjson
+{{- end }}


### PR DESCRIPTION
Whilst not required for the AKS Development deployment, as the secret it generated externally via script, the secret is required in order to create the Rebuilt Pod in the Rancher Deployment