### PR TITLE
cadded changes for stateful set

### DIFF
--- a/adaptation/templates/rabbitmq-server-service.yaml
+++ b/adaptation/templates/rabbitmq-server-service.yaml
@@ -7,6 +7,10 @@ metadata:
   name: {{ .Values.rabbitmqService.name }}
 spec:
  replicas: 3
+ override:
+  statefulSet:
+    spec:
+      podManagementPolicy: Parallel
 {{- if .Values.imagestore.rabbitmq }} 
  image: "{{ .Values.imagestore.rabbitmq.registry }}{{ .Values.imagestore.rabbitmq.repository }}:{{ .Values.imagestore.rabbitmq.tag }}"
  imagePullSecrets:


### PR DESCRIPTION
The change to the stateful set using "Parallel" means that the pods start up together now, rather than one after another. 

This change now means if the pods are deleted, rabbit will not crash and will start back up correctly.