### PR TITLE
introduce randomized delay to solve issues

### DIFF
--- a/adaptation/templates/rabbitmq-server-service.yaml
+++ b/adaptation/templates/rabbitmq-server-service.yaml
@@ -28,6 +28,10 @@ spec:
             values:
             - store
          topologyKey: kubernetes.io/hostname
+ rabbitmq:
+   additionalConfig: |
+    cluster_formation.randomized_startup_delay_range.min = 5
+    cluster_formation.randomized_startup_delay_range.max = 60
  resources:
   requests:
     cpu: 1000m
@@ -35,6 +39,3 @@ spec:
   limits:
     cpu: 1000m
     memory: 2Gi
- persistence:
-   storageClassName: azurefile
-   storage: 10Gi

--- a/adaptation/templates/rabbitmq-server-service.yaml
+++ b/adaptation/templates/rabbitmq-server-service.yaml
@@ -39,3 +39,6 @@ spec:
   limits:
     cpu: 1000m
     memory: 2Gi
+ persistence:
+   storageClassName: azurefile
+   storage: 10Gi


### PR DESCRIPTION
I believe the use of Parallel for podManagementPolicy is causing the RabbitMQ issues we are seeing on the cluster. 

Nodes are not all joining the same RabbitMQ Cluster, on develop, Node 0 and Node 1 were part of the same cluster, however Node 2 was in a standalone cluster. This was causing messages to be stuck in the queue, as depending on which node the service was connected to, it could either see them or not. After manually adding Node 2 to the same cluster as 0 and 1, no more messages are getting stuck in the queue.

They have however implemented a randomized startup delay configuration to work around this:

> Peer discovery mechanism will filter out nodes whose pods are not yet ready (initialised) according to their readiness probe as reported by the Kubernetes API. For example, if pod management policy of a stateful set is set to Parallel, some nodes may be discovered but will not be joined. To work around this, the Kubernetes peer discovery plugin uses randomized startup delays.

https://www.rabbitmq.com/cluster-formation.html#peer-discovery-k8s
https://www.rabbitmq.com/cluster-formation.html#initial-formation-race-condition