### PR TITLE
add systemclusterrole. The systemclusterrome we added is for storage …

### DIFF
--- a/systemclusterrole/Chart.yaml
+++ b/systemclusterrole/Chart.yaml
@@ -1,0 +1,23 @@
+apiVersion: v2
+name: systemclusterrole
+description: A Helm chart for Kubernetes
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+appVersion: 1.16.0

--- a/systemclusterrole/templates/azuredisk.yaml
+++ b/systemclusterrole/templates/azuredisk.yaml
@@ -1,0 +1,10 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: azuredisk
+parameters:
+  storageaccounttype: Standard_LRS
+provisioner: kubernetes.io/azure-disk
+reclaimPolicy: Delete
+volumeBindingMode: Immediate
+allowVolumeExpansion: false

--- a/systemclusterrole/templates/clusterrole.yaml
+++ b/systemclusterrole/templates/clusterrole.yaml
@@ -1,0 +1,8 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ .Values.metadataName }}
+rules:
+  - apiGroups: ['']
+    resources: ['secrets']
+    verbs:     ['get','create']

--- a/systemclusterrole/templates/clusterrolebinding.yaml
+++ b/systemclusterrole/templates/clusterrolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ .Values.metadataName }}
+roleRef:
+  kind: ClusterRole
+  apiGroup: rbac.authorization.k8s.io
+  name: {{ .Values.metadataName }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Values.serviceAccountName }}
+    namespace: kube-system

--- a/systemclusterrole/templates/storageclass.yaml
+++ b/systemclusterrole/templates/storageclass.yaml
@@ -1,0 +1,8 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: azurefile
+provisioner: kubernetes.io/azure-file
+reclaimPolicy: Delete
+volumeBindingMode: Immediate
+allowVolumeExpansion: false

--- a/systemclusterrole/values.yaml
+++ b/systemclusterrole/values.yaml
@@ -1,0 +1,4 @@
+metadataName: "system:azure-cloud-provider"
+
+
+serviceAccountName: "persistent-volume-binder"

--- a/systemclusterrole/values.yaml
+++ b/systemclusterrole/values.yaml
@@ -1,4 +1,2 @@
 metadataName: "system:azure-cloud-provider"
-
-
 serviceAccountName: "persistent-volume-binder"


### PR DESCRIPTION
The systemclusterrome we added is for storage provisioning and thus needs to be on racher clusters but not AKS ones.
It allows the code that auto-privisoins Azure Files shares to interact with Kubernetes APIs.