### PR TITLE
Set the c-icap timeout configuration value to 4s

### DIFF
--- a/adaptation/values.yaml
+++ b/adaptation/values.yaml
@@ -71,7 +71,7 @@ cicapservice:
   conf:
     PidFile: /var/run/c-icap/c-icap.pid
     CommandsSocket: /var/run/c-icap/c-icap.ctl
-    Timeout: 300
+    Timeout: 4
     MaxKeepAliveRequests: 100
     KeepAliveTimeout: 600
     StartServers: 3


### PR DESCRIPTION
Addressing issue #295 