### PR TITLE
Merge changes to improve ICAP Port responsiveness

### DIFF
--- a/adaptation/templates/lb_service.yaml
+++ b/adaptation/templates/lb_service.yaml
@@ -6,6 +6,7 @@ metadata:
   name: frontend-icap-lb
 spec:
   type: LoadBalancer
+  externalTrafficPolicy: Local
   ports:
   - name: icap-port
     port: {{ .Values.lbService.nontlsport }}

--- a/adaptation/values.yaml
+++ b/adaptation/values.yaml
@@ -71,7 +71,7 @@ cicapservice:
   conf:
     PidFile: /var/run/c-icap/c-icap.pid
     CommandsSocket: /var/run/c-icap/c-icap.ctl
-    Timeout: 300
+    Timeout: 4
     MaxKeepAliveRequests: 100
     KeepAliveTimeout: 600
     StartServers: 3


### PR DESCRIPTION
The ICAP Port timeout is reduced to 4s to avoid Health Probes connections from backing up.
The `externalTrafficPolicy` is set to `local` to improve responsiveness of the port.